### PR TITLE
feat: Add Python and Scapy to ueransim for testing

### DIFF
--- a/ueransim/rockcraft.yaml
+++ b/ueransim/rockcraft.yaml
@@ -42,3 +42,9 @@ parts:
         - iproute2
         - iptables
         - iputils-ping
+
+  scapy:
+    plugin: nil
+    stage-packages:
+      - python3
+      - python3-scapy


### PR DESCRIPTION
# Description

This adds Python and Scapy to the ueransim rock to be used in testing. This will enable running advanced connectivity scenarios in the integration tests.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.